### PR TITLE
Fix prefixes when building a query

### DIFF
--- a/src/Legrand/SPARQL.php
+++ b/src/Legrand/SPARQL.php
@@ -215,7 +215,7 @@ class SPARQL {
 		//PREFIXES
 		foreach($this->prefixes as $pre)
 		{
-			$sp .= $pre + " ";
+			$sp .= $pre . " ";
 		}
 
 		//VARIABLES

--- a/src/Legrand/SPARQL.php
+++ b/src/Legrand/SPARQL.php
@@ -65,7 +65,7 @@ class SPARQL {
 
 	public function prefixe($ns, $x)
 	{ 
-		$this->prefixes[] = "PREFIX $ns : <$x>"; 
+		$this->prefixes[] = "PREFIX $ns: <$x>\n"; 
 		return $this; 
 	}
 	public function distinct($bool)

--- a/tests/SparqlTest.php
+++ b/tests/SparqlTest.php
@@ -176,7 +176,7 @@ class SparqlTest extends PHPUnit_Framework_TestCase
         $sparql = new Legrand\SPARQL;
         $sparql->prefixe('foaf', 'http://xmlns.com/foaf/0.1/')->select('http://graph')->where('<http://element/id>', '?x', '?y')->groupBy('?x');
 
-        $expected = 'PREFIX foaf : <http://xmlns.com/foaf/0.1/> SELECT * WHERE { GRAPH <http://graph> { <http://element/id> ?x ?y } } GROUP BY ?x';
+        $expected = 'PREFIX foaf: <http://xmlns.com/foaf/0.1/>  SELECT * WHERE { GRAPH <http://graph> { <http://element/id> ?x ?y } } GROUP BY ?x';
 
         $actual = $this->cleanQuery($sparql->getQuery());
 

--- a/tests/SparqlTest.php
+++ b/tests/SparqlTest.php
@@ -171,6 +171,18 @@ class SparqlTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual, 'The simple query with a filter');
     }
 
+    public function testPrefixes()
+    {
+        $sparql = new Legrand\SPARQL;
+        $sparql->prefixe('foaf', 'http://xmlns.com/foaf/0.1/')->select('http://graph')->where('<http://element/id>', '?x', '?y')->groupBy('?x');
+
+        $expected = 'PREFIX foaf : <http://xmlns.com/foaf/0.1/> SELECT * WHERE { GRAPH <http://graph> { <http://element/id> ?x ?y } } GROUP BY ?x';
+
+        $actual = $this->cleanQuery($sparql->getQuery());
+
+        $this->assertEquals($expected, $actual, 'The simple query with prefixes');
+    }
+
 
 
 


### PR DESCRIPTION
Hi, thanks for sparq-php, very useful library!

I found a bug in the way it appends prefixes to the Query string which limits my use in my app. Hope it helps.

Bruno